### PR TITLE
End times should be outside of %"...%"

### DIFF
--- a/ical2rem.pl
+++ b/ical2rem.pl
@@ -332,6 +332,7 @@ foreach $yearkey (sort keys %{$events} ) {
                 print "%\"", &quote($event->{'SUMMARY'});
                 print(" at ", &quote($event->{'LOCATION'}))
                     if ($do_location and $event->{'LOCATION'});
+                print "\%\"";
                 if ($do_end_times and ($start->hour or $start->minute or
                                        $end->hour or $end->minute)) {
                     my $start_date = $start->strftime("%F");
@@ -352,7 +353,7 @@ foreach $yearkey (sort keys %{$events} ) {
                     }
                     print " (-", join(" ", @pieces), ")";
                 }
-                print "\%\"%\n";
+                print "%\n";
             }
         }
     }


### PR DESCRIPTION
Although the remind documentation claims that remind doesn't actually
use `DURATION` for anything, that's not entirely accurate. It turns
out that both `rem -c` and `rem2ps` display reminder end times when
both `AT` and `DURATION` are both specified. Therefore, it's not
necessary to put the end time explicitly inside the %"...%" calendar
markers.