### PR TITLE
No DURATION without AT

### DIFF
--- a/ical2rem.pl
+++ b/ical2rem.pl
@@ -332,6 +332,7 @@ foreach $yearkey (sort keys %{$events} ) {
                 print "%\"", &quote($event->{'SUMMARY'});
                 print(" at ", &quote($event->{'LOCATION'}))
                     if ($do_location and $event->{'LOCATION'});
+                print "\%\"";
                 if ($do_end_times and ($start->hour or $start->minute or
                                        $end->hour or $end->minute)) {
                     my $start_date = $start->strftime("%F");
@@ -352,7 +353,7 @@ foreach $yearkey (sort keys %{$events} ) {
                     }
                     print " (-", join(" ", @pieces), ")";
                 }
-                print "\%\"%\n";
+                print "%\n";
             }
         }
     }

--- a/ical2rem.pl
+++ b/ical2rem.pl
@@ -313,21 +313,21 @@ foreach $yearkey (sort keys %{$events} ) {
                     my $minutes = int($seconds / 60);
                     my $hours = int($minutes / 60);
                     $minutes -= $hours * 60;
-                    $duration = sprintf("DURATION %d:%02d", $hours, $minutes);
+                    $duration = sprintf("DURATION %d:%02d ", $hours, $minutes);
                 }
                 print "REM ";
                 if ($iso8601) {
-                    print $start->strftime("%F");
+                    print $start->strftime("%F ");
                 } else {
-                    print $start->month_abbr." ".$start->day." ".$start->year;
+                    print $start->month_abbr." ".$start->day." ".$start->year." ";
                 }
-                print " $leadtime ";
-                if ($start->hour > 0 or $start->minute > 0) {
-                    print " AT ";
+                print "$leadtime ";
+                if ($duration or $start->hour > 0 or $start->minute > 0) {
+                    print "AT ";
                     print $start->strftime("%H:%M");
-                    print " SCHED _sfun ${duration} MSG %a %2 ";
+                    print " SCHED _sfun ${duration}MSG %a %2 ";
                 } else {
-                    print "${duration} MSG %a ";
+                    print "MSG %a ";
                 }
                 print "%\"", &quote($event->{'SUMMARY'});
                 print(" at ", &quote($event->{'LOCATION'}))


### PR DESCRIPTION
The current version of remind doesn't allow DURATION to be specified without AT.

Also, while we're at it remove some extra spaces from the reminder output.
